### PR TITLE
Flytter FintResourceObject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 
 dependencies {
     implementation 'javax.validation:validation-api:2.0.1.Final'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 }
 
 javadoc {

--- a/src/main/java/no/fint/model/FintObject.java
+++ b/src/main/java/no/fint/model/FintObject.java
@@ -1,5 +1,7 @@
 package no.fint.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,9 +14,11 @@ public interface FintObject extends Serializable {
      * By default, this method returns an empty list, as not all objects may have relations.
      * Most use cases will involve {@code FintMetaObject}s, as they contain the metadata required.
      * There are some use cases where a {@code FintComplexDatatypeObject} may have relations.
+     *
      * @return a list of {@link FintRelation} objects representing the relationships this object
      * has with other resource objects. Returns an empty list by default.
      */
+    @JsonIgnore
     default List<FintRelation> getRelations() {
         return new ArrayList<>();
     }

--- a/src/main/java/no/fint/model/FintResourceObject.java
+++ b/src/main/java/no/fint/model/FintResourceObject.java
@@ -1,4 +1,0 @@
-package no.fint.model;
-
-public interface FintResourceObject extends FintMainObject {
-}


### PR DESCRIPTION
FintResourceObject burde inneholde en relasjon til [FintLinks](https://github.com/FINTmodels/fint-model-resource/blob/master/src/main/java/no/fint/model/resource/FintLinks.java).
[fint-model-resource](https://github.com/FINTmodels/fint-model-resource) biblioteket blir kunn brukt i resource pakkene til java bibliotekene.
Derfor gir det mening at den bør ta i bruk dette prosjektet i sin gradle fil, slik den kan fortsatt arve FintMainObject.
